### PR TITLE
Put boxes with ? for missing letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,13 @@
                                 </div>
                             </div>
                         </div>
+                        <div v-for="space in missing_letters" class="tile col-3">
+                            <div class="thumbnail">
+                                <div class="square">
+                                    <div class="letter">?</div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div id="control-panel" class="panel col-md-12 col-lg-8">

--- a/js/display_board.js
+++ b/js/display_board.js
@@ -148,6 +148,9 @@ var app = new Vue({
             return Object.getOwnPropertyNames(words_by_length)
                 .map(length => ({ "length": length, "words": words_by_length[length] }))
                 .reverse();
+        },
+        missing_letters: function missing_letters(){
+            return new Array(16 - this.letters.length);
         }
     },
     mounted: function mounted() {


### PR DESCRIPTION
Previously, boxes in the grid that didn't have a corresponding letter would simply vanish, changing the layout of the page. This puts boxes with question marks in their place to keep things consistent.